### PR TITLE
fix: resolve ESLint configuration inconsistencies and code quality issues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+  "eslint.workingDirectories": ["."],
+  "eslint.options": {
+    "ignorePattern": [
+      ".next/**",
+      "out/**", 
+      "build/**",
+      "dist/**",
+      "node_modules/**",
+      "coverage/**",
+      "test-results/**",
+      "playwright-report/**"
+    ]
+  },
+  "eslint.validate": [
+    "typescript",
+    "typescriptreact",
+    "javascript",
+    "javascriptreact"
+  ],
+  "eslint.lintTask.enable": true,
+  "typescript.preferences.includePackageJsonAutoImports": "on"
+}

--- a/e2e/auth-todo-integration.spec.ts
+++ b/e2e/auth-todo-integration.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect, Page } from '@playwright/test';
-import { TEST_USER } from './helpers/auth';
 
 // Helper function to create a unique test user
 async function createTestUser(page: Page) {

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -30,7 +30,7 @@ export async function login(page: Page, email: string, password: string) {
     page.waitForSelector('[data-sonner-toast][data-type="error"], .text-red-500, .text-red-600', { timeout: 10000 }).then(() => {
       throw new Error('Login error detected');
     })
-  ]).catch(async (error) => {
+  ]).catch(async () => {
     // Handle errors
     const errorToast = page.locator('[data-sonner-toast][data-type="error"]');
     const hasErrorToast = await errorToast.isVisible({ timeout: 1000 }).catch(() => false);

--- a/e2e/mocks/handlers.ts
+++ b/e2e/mocks/handlers.ts
@@ -2,6 +2,14 @@ import { http, HttpResponse } from 'msw';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api/v1';
 
+// Types for API requests
+interface TodoRequest {
+  title: string;
+  description: string;
+  status: string;
+  priority: string;
+}
+
 // Mock data
 let todos = [
   {
@@ -99,7 +107,7 @@ export const handlers = [
       );
     }
     
-    const body = await request.json() as any;
+    const body = await request.json() as TodoRequest;
     const newTodo = {
       id: nextId++,
       ...body,
@@ -122,7 +130,7 @@ export const handlers = [
     }
     
     const id = Number(params.id);
-    const body = await request.json() as any;
+    const body = await request.json() as TodoRequest;
     const index = todos.findIndex(t => t.id === id);
     
     if (index === -1) {

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -11,7 +11,6 @@ test.describe('Smoke Tests', () => {
     await expect(page).toHaveTitle(/TODO App/);
     
     // Log current page content for debugging
-    const pageContent = await page.content();
     console.log('Page URL:', page.url());
     console.log('Page title:', await page.title());
     

--- a/e2e/todo-basic.spec.ts
+++ b/e2e/todo-basic.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { setupTestUser, createUniqueTestUser } from './helpers/setup';
+import { createUniqueTestUser } from './helpers/setup';
 import { login } from './helpers/auth';
 
 test.describe('Todo Basic Operations', () => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,26 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  {
+    ignores: [
+      ".next/**",
+      "out/**", 
+      "build/**",
+      "dist/**",
+      "node_modules/**",
+      "coverage/**",
+      "test-results/**",
+      "playwright-report/**",
+      "public/mockServiceWorker.js"
+    ]
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    files: ["e2e/**/*"],
+    rules: {
+      "react-hooks/rules-of-hooks": "off"
+    }
+  },
 ];
 
 export default eslintConfig;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const nextJest = require('next/jest')
 
 const createJestConfig = nextJest({

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:debug": "NODE_OPTIONS='--inspect' next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "next lint -d .",
     "type-check": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/playwright/global-setup.ts
+++ b/playwright/global-setup.ts
@@ -1,6 +1,6 @@
-import { chromium, FullConfig } from '@playwright/test';
+import { chromium } from '@playwright/test';
 
-async function globalSetup(config: FullConfig) {
+async function globalSetup() {
   // Set up MSW for CI environment
   if (process.env.CI) {
     console.log('CI environment detected - MSW will be used for API mocking');

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /* tslint:disable */
 
 /**


### PR DESCRIPTION
## Summary
- Fix ESLint configuration to match `npm run lint` with VS Code experience
- Resolve 9 ESLint errors through proper configuration and code improvements
- Enhance development consistency across different environments

## Changes Made

### ESLint Configuration
- **Updated package.json**: Changed lint command to `next lint -d .` for full directory scanning
- **Enhanced eslint.config.mjs**: Added proper ignore patterns for build outputs and generated files
- **E2E specific rules**: Disabled `react-hooks/rules-of-hooks` for Playwright test files

### Code Quality Improvements
- **Removed unused imports**: Cleaned up `TEST_USER`, `setupTestUser` across e2e test files
- **Fixed unused variables**: Proper handling of error parameters and config arguments
- **Type safety**: Replaced `any` types with proper `TodoRequest` interface in mock handlers
- **Tool-specific handling**: Added appropriate ESLint disable comments for Jest and Playwright

### Developer Experience
- **VS Code settings**: Created workspace-specific ESLint configuration for consistent experience
- **Build output exclusion**: Properly ignore `.next/`, `dist/`, coverage files from linting

## Test Results
- ✅ **Type-check**: Passing
- ✅ **Lint**: 0 errors (was 9 errors)
- ✅ **Build**: Successful

## Impact
This resolves the discrepancy between `npm run lint` and VS Code ESLint extension, ensuring developers see consistent linting results across all environments.

🤖 Generated with [Claude Code](https://claude.ai/code)